### PR TITLE
docker-apt-cacher-ng

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,3 +22,7 @@ resource "nomad_job" "acs-interface" {
 resource "nomad_job" "ingress" {
   jobspec = "${file("${path.module}/nomad_jobs/ingress.hcl")}"
 }
+
+resource "nomad_job" "apt-cacher-ng" {
+  jobspec = "${file("${path.module}/nomad_jobs/apt-cacher-ng.hcl")}"
+}

--- a/nomad_jobs/apt-cacher-ng.hcl
+++ b/nomad_jobs/apt-cacher-ng.hcl
@@ -1,0 +1,43 @@
+job "apt-cacher-ng" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "apt-cacher-ng" {
+    task "apt-cacher-ng" {
+      constraint {
+        attribute = "${meta.volumes}"
+        operator  = "is_set"
+      }
+      driver = "docker"
+      config {
+        image = "sameersbn/apt-cacher-ng:3.1-3"
+        volumes = [
+          "${meta.volumes}/apt-cacher-ng:/var/cache/apt-cacher-ng",
+        ]
+        port_map {
+          http = 3142
+        }
+      }
+      resources {
+        memory = 200
+        cpu = 100
+        network {
+          port "http" {
+            static = 9100
+          }
+        }
+      }
+      service {
+        name = "apt-cacher-ng"
+        port = "http"
+        check {
+          name = "apt-cacher-ng alive on http"
+          initial_status = "critical"
+          type = "tcp"
+          interval = "5s"
+          timeout = "5s"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Not deployed yet. Fixes https://github.com/vmck/acs-interface/issues/120

Source: https://github.com/sameersbn/docker-apt-cacher-ng
Usage in VMs: https://github.com/sameersbn/docker-apt-cacher-ng#usage
