### PR TITLE
`bin/nomad` script

### DIFF
--- a/bin/nomad
+++ b/bin/nomad
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+export NOMAD_ADDR=http://10.42.2.1:4646
+
+set -x
+nomad "$@"


### PR DESCRIPTION
For when you want to use the Nomad CLI on the cluster but don't want to type `export NOMAD_ADDR=...`.